### PR TITLE
Session 5: Error 

### DIFF
--- a/WhetherApp.xcodeproj/project.pbxproj
+++ b/WhetherApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		54605CAC2AA57C8C003FEFC6 /* YumemiWeather in Frameworks */ = {isa = PBXBuildFile; productRef = 54605CAB2AA57C8C003FEFC6 /* YumemiWeather */; };
 		54605CD12AA5DCCA003FEFC6 /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54605CD02AA5DCCA003FEFC6 /* LaunchViewController.swift */; };
 		54605CD32AA5DE47003FEFC6 /* LaunchView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 54605CD22AA5DE47003FEFC6 /* LaunchView.storyboard */; };
+		54BFE1BB2AAFFC8A00FC3573 /* WeatherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BFE1BA2AAFFC8A00FC3573 /* WeatherError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,6 +36,7 @@
 		54605CA42AA57C5A003FEFC6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		54605CD02AA5DCCA003FEFC6 /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
 		54605CD22AA5DE47003FEFC6 /* LaunchView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchView.storyboard; sourceTree = "<group>"; };
+		54BFE1BA2AAFFC8A00FC3573 /* WeatherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +83,7 @@
 				54605C9A2AA57C59003FEFC6 /* WeatherViewController.swift */,
 				545A7D082AA87B370092CFE1 /* WeatherRepositoryDelegate.swift */,
 				545A7D062AA83C190092CFE1 /* WeatherRepository.swift */,
+				54BFE1BA2AAFFC8A00FC3573 /* WeatherError.swift */,
 				544FB4352AA7350E000E74D4 /* Enum */,
 				54605CD02AA5DCCA003FEFC6 /* LaunchViewController.swift */,
 				54605CD22AA5DE47003FEFC6 /* LaunchView.storyboard */,
@@ -177,6 +180,7 @@
 				54605C992AA57C59003FEFC6 /* SceneDelegate.swift in Sources */,
 				545A7D092AA87B370092CFE1 /* WeatherRepositoryDelegate.swift in Sources */,
 				54605CD12AA5DCCA003FEFC6 /* LaunchViewController.swift in Sources */,
+				54BFE1BB2AAFFC8A00FC3573 /* WeatherError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WhetherApp/WeatherError.swift
+++ b/WhetherApp/WeatherError.swift
@@ -1,0 +1,42 @@
+//
+//  WeatherError.swift
+//  WhetherApp
+//
+//  Created by 瀬川 裕翔 on 2023/09/12.
+//
+
+import Foundation
+import YumemiWeather
+
+enum WeatherError: Error {
+    case invalidParameterError
+    case invalidResponse
+    case unknownError
+    
+    init(_ error: Error) {
+        guard let weatherError = error as? YumemiWeatherError else {
+            self = .invalidResponse
+            return
+        }
+        
+        switch weatherError {
+        case .invalidParameterError:
+            self = .invalidParameterError
+        case .unknownError:
+            self = .unknownError
+        }
+    }
+}
+
+extension WeatherError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .invalidParameterError:
+            return "Invalid parameter error"
+        case .invalidResponse:
+            return "Invalid response"
+        case .unknownError:
+            return "Unknown error"
+        }
+    }
+}

--- a/WhetherApp/WeatherError.swift
+++ b/WhetherApp/WeatherError.swift
@@ -9,9 +9,9 @@ import Foundation
 import YumemiWeather
 
 enum WeatherError: Error {
-    case invalidParameterError
+    case invalidParameter
     case invalidResponse
-    case unknownError
+    case unknown
     
     init(_ error: Error) {
         guard let weatherError = error as? YumemiWeatherError else {
@@ -21,9 +21,9 @@ enum WeatherError: Error {
         
         switch weatherError {
         case .invalidParameterError:
-            self = .invalidParameterError
+            self = .invalidParameter
         case .unknownError:
-            self = .unknownError
+            self = .unknown
         }
     }
 }
@@ -31,11 +31,11 @@ enum WeatherError: Error {
 extension WeatherError: LocalizedError {
     var errorDescription: String? {
         switch self {
-        case .invalidParameterError:
-            return "Invalid parameter error"
+        case .invalidParameter:
+            return "Invalid parameter"
         case .invalidResponse:
             return "Invalid response"
-        case .unknownError:
+        case .unknown:
             return "Unknown error"
         }
     }

--- a/WhetherApp/WeatherRepository.swift
+++ b/WhetherApp/WeatherRepository.swift
@@ -24,7 +24,7 @@ class WeatherRepository: WeatherRepositoryProtocol {
             }
             delegate?.weatherRepository(self, didFetchWeatherCondition: weather)
         } catch {
-            delegate?.weatherRepository(self, didFailWithError: error)
+            delegate?.weatherRepository(self, didFailWithError: WeatherError(error))
         }
     }
 }

--- a/WhetherApp/WeatherRepository.swift
+++ b/WhetherApp/WeatherRepository.swift
@@ -17,9 +17,14 @@ class WeatherRepository: WeatherRepositoryProtocol {
     weak var delegate: WeatherRepositoryDelegate?
     
     func fetchWeatherCondition() {
-        guard let weather = WeatherCondition(rawValue: YumemiWeather.fetchWeatherCondition()) else {
-            fatalError("Fail to convert String to WeatherCondition")
+        do {
+            let weatherString = try YumemiWeather.fetchWeatherCondition(at: "Tokyo")
+            guard let weather = WeatherCondition(rawValue: weatherString) else {
+                fatalError("Fail to convert String to WeatherCondition")
+            }
+            delegate?.weatherRepository(self, didFetchWeatherCondition: weather)
+        } catch {
+            delegate?.weatherRepository(self, didFailWithError: error)
         }
-        delegate?.weatherRepository(self, didFetchWeatherCondition: weather)
     }
 }

--- a/WhetherApp/WeatherRepositoryDelegate.swift
+++ b/WhetherApp/WeatherRepositoryDelegate.swift
@@ -9,6 +9,6 @@ import Foundation
 
 protocol WeatherRepositoryDelegate: AnyObject {
     func weatherRepository(_ weatherRepository: WeatherRepositoryProtocol, didFetchWeatherCondition condition: WeatherCondition)
-    func weatherRepository(_ weatherRepository: WeatherRepositoryProtocol, didFailWithError error: Error)
+    func weatherRepository(_ weatherRepository: WeatherRepositoryProtocol, didFailWithError error: WeatherError)
 }
 

--- a/WhetherApp/WeatherRepositoryDelegate.swift
+++ b/WhetherApp/WeatherRepositoryDelegate.swift
@@ -9,5 +9,6 @@ import Foundation
 
 protocol WeatherRepositoryDelegate: AnyObject {
     func weatherRepository(_ weatherRepository: WeatherRepositoryProtocol, didFetchWeatherCondition condition: WeatherCondition)
+    func weatherRepository(_ weatherRepository: WeatherRepositoryProtocol, didFailWithError error: Error)
 }
 

--- a/WhetherApp/WeatherViewController.swift
+++ b/WhetherApp/WeatherViewController.swift
@@ -39,7 +39,7 @@ extension WeatherViewController: WeatherRepositoryDelegate {
         weatherImage.tintColor = getImageColor(for: condition)
     }
     
-    func weatherRepository(_ weatherRepository: WeatherRepositoryProtocol, didFailWithError error: Error) {
+    func weatherRepository(_ weatherRepository: WeatherRepositoryProtocol, didFailWithError error: WeatherError) {
         let alert = UIAlertController(title: "Alert", message: error.localizedDescription, preferredStyle: .alert)
         let done = UIAlertAction(title: "OK", style: .default)
         alert.addAction(done)

--- a/WhetherApp/WeatherViewController.swift
+++ b/WhetherApp/WeatherViewController.swift
@@ -38,6 +38,13 @@ extension WeatherViewController: WeatherRepositoryDelegate {
         weatherImage.image = UIImage(named: getImageName(for: condition))
         weatherImage.tintColor = getImageColor(for: condition)
     }
+    
+    func weatherRepository(_ weatherRepository: WeatherRepositoryProtocol, didFailWithError error: Error) {
+        let alert = UIAlertController(title: "Alert", message: error.localizedDescription, preferredStyle: .alert)
+        let done = UIAlertAction(title: "OK", style: .default)
+        alert.addAction(done)
+        present(alert, animated: true)
+    }
 }
 
 // MARK: Private


### PR DESCRIPTION
## 概要
・呼び出しAPIをthrowsに変更
・エラー取得時にAlertを表示

### 課題URL
https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Error.md

### 変更点概略
呼び出しエラー時にエラーに応じてアラートメッセージを変更し表示する。

```swift
class WeatherRepository: WeatherRepositoryProtocol {
    weak var delegate: WeatherRepositoryDelegate?
    
    func fetchWeatherCondition() {
        do {
            let weatherString = try YumemiWeather.fetchWeatherCondition(at: "Tokyo")
            guard let weather = WeatherCondition(rawValue: weatherString) else {
                fatalError("Fail to convert String to WeatherCondition")
            }
            delegate?.weatherRepository(self, didFetchWeatherCondition: weather)
        } catch {
            delegate?.weatherRepository(self, didFailWithError: error)
        }
    }
}
```
```swift
extension WeatherViewController: WeatherRepositoryDelegate {
    func weatherRepository(_ weatherRepository: WeatherRepositoryProtocol, didFailWithError error: Error) {
        let alert = UIAlertController(title: "Alert", message: error.localizedDescription, preferredStyle: .alert)
        let done = UIAlertAction(title: "OK", style: .default)
        alert.addAction(done)
        present(alert, animated: true)
    }
}
```

### 変更後
https://github.com/yumemi-inc/ios-training-laiug787-WhetherApp/assets/86225588/2778b6f0-a2d1-4936-96d8-134d0f410e60